### PR TITLE
Convert evalute() argument to numpy array

### DIFF
--- a/test_functions/test_funcs.py
+++ b/test_functions/test_funcs.py
@@ -113,6 +113,7 @@ class TestFunction(object):
         return '{0}({1})'.format(self.__class__.__name__, self.dim)
 
     def evaluate(self, x):
+        x = numpy.asarray(x)
         if x.shape != (self.dim,):
           raise ValueError('Argument must be a numpy array of length {}'.format(self.dim))
 
@@ -3707,4 +3708,3 @@ class Problem22(TestFunction):
     def do_evaluate(self, x):
         x = x[0]
         return exp(-3 * x) - (sin(x)) ** 3
-


### PR DESCRIPTION
Allow users to pass in a list instead of array.
